### PR TITLE
Add tzachb/Homeseer-HA to HACS default

### DIFF
--- a/integration
+++ b/integration
@@ -234,6 +234,7 @@
   "bywciu/Home-Assistant-Custom-Components-ReversoTTS",
   "c-st/auto_areas",
   "c0un7-z3r0/hass-phoniebox",
+  "c1pher-cn/ha-mcp-for-xiaozhi",
   "c1pher-cn/heweather",
   "c1pher-cn/homeassistan-ezviz",
   "cabberley/HA_AemoNemData",

--- a/integration
+++ b/integration
@@ -1014,6 +1014,7 @@
   "MiguelAngelLV/ha-input-stats",
   "MiguelAngelLV/ha-octopus-spain",
   "MiguelAngelLV/ha-tarifa-20td",
+  "MiguelTVMS/e-redes-smart-metering-plus-hass",
   "mike81gr/deddie-metering",
   "mikelawrence/senseme-hacs",
   "mill1000/midea-ac-py",

--- a/integration
+++ b/integration
@@ -672,6 +672,7 @@
   "hyperb1iss/signalrgb-homeassistant",
   "Hyundai-Kia-Connect/kia_uvo",
   "hzjchina/hass-welock",
+  "ia74/roomba_rest980",
   "IATkachenko/HA-SleepAsAndroid",
   "IATkachenko/HA-YandexWeather",
   "Ibepower/Ibepower-Homeassistant-Integration",

--- a/integration
+++ b/integration
@@ -959,6 +959,7 @@
   "MarcoGos/kleenex_pollenradar",
   "marcolivierarsenault/moonraker-home-assistant",
   "mariusz-ostoja-swierczynski/tech-controllers",
+  "markfrancisonly/ha-cameralux",
   "markgdev/home-assistant_OctopusAgile",
   "markuzzi/somfy_cul_integration",
   "markvader/ha-rpi_rf",

--- a/integration
+++ b/integration
@@ -674,6 +674,7 @@
   "Hyundai-Kia-Connect/kia_uvo",
   "hzjchina/hass-welock",
   "ia74/roomba_rest980",
+  "iamkarlson/grocy",
   "IATkachenko/HA-SleepAsAndroid",
   "IATkachenko/HA-YandexWeather",
   "Ibepower/Ibepower-Homeassistant-Integration",

--- a/integration
+++ b/integration
@@ -452,6 +452,7 @@
   "dphae/bsh",
   "drakhart/ha-super-soco-custom",
   "drc38/Fronius_solarweb",
+  "droans/mass_queue",
   "droso-hass/idfm",
   "dscao/ikuai",
   "DSorlov/swemail",

--- a/integration
+++ b/integration
@@ -1297,6 +1297,7 @@
   "ryanmac8/HA-Mint-Mobile",
   "ryanmac8/Home-Assistant-Marta",
   "rytilahti/homeassistant-upnp-availability",
+  "rzulian/lutron_lip",
   "samjsmart/ha-zone4",
   "samoswall/polaris-mqtt",
   "samspade21/vacasa-ha",

--- a/integration
+++ b/integration
@@ -1426,6 +1426,7 @@
   "Taraman17/hass-homee",
   "tarikbc/ha-ppa-contatto",
   "Tasshack/dreame-vacuum",
+  "tbclark3/homeassistant-xweather",
   "tbouron/ha-agur",
   "tcarwash/home-assistant_noaa-space-weather",
   "tefinger/hass-brematic",

--- a/integration
+++ b/integration
@@ -252,6 +252,7 @@
   "cdnninja/yoto_ha",
   "chaimchaikin/molad-ha",
   "CharlesGillanders/homeassistant-alphaESS",
+  "CharlesP44/Beem_Energy",
   "Chiralistic/home-assistant-schulferien",
   "chises/ha-oilfox",
   "chkuendig/hass-ab_ble_gateway",

--- a/integration
+++ b/integration
@@ -735,6 +735,7 @@
   "jekalmin/extended_openai_conversation",
   "jellespijker/home-assistant-ultimaker",
   "Jems22/ha_star_rennes",
+  "JeppeLeth/hass-ista-online",
   "jeroenterheerdt/grillbuddy",
   "jeroenterheerdt/HADailySensor",
   "jeroenterheerdt/HAsmartirrigation",

--- a/plugin
+++ b/plugin
@@ -165,6 +165,7 @@
   "GeorgeSG/lovelace-time-picker-card",
   "georgezhao2010/lovelace-curtain-card",
   "Gh61/lovelace-hue-like-light-card",
+  "goggybox/compact-light-card",
   "grinstantin/todoist-card",
   "gurbyz/power-wheel-card",
   "GyroGearl00se/lovelace-froeling-card",

--- a/plugin
+++ b/plugin
@@ -311,6 +311,7 @@
   "Nicxe/home-assistant-smhialert-card",
   "nielsfaber/alarmo-card",
   "nielsfaber/scheduler-card",
+  "nitaybz/apple-home-dashboard",
   "nutteloost/actions-card",
   "nutteloost/simple-swipe-card",
   "nutteloost/todo-swipe-card",


### PR DESCRIPTION
this PR adds the `tzachb/Homeseer-HA` integration to the HACS default list.

The repository follows the HACS structure:

- `hacs.json` is in the root
- `custom_components/homeseer/` includes `manifest.json` (with issue_tracker), integration files
- `.github/workflows/hacs.yaml` exists for validation

**Repository:** https://github.com/tzachb/Homeseer-HA  
**Issue tracker:** https://github.com/tzachb/Homeseer-HA/issues  
**Workflow file:** https://github.com/tzachb/Homeseer-HA/blob/main/.github/workflows/hacs.yaml  
**Successful Validate HACS run:** [link to latest passing run in Actions tab]

@hacs/integration-maintainers — The repository has been cleaned and passes validation.  
Please approve the workflows so the checks can run.